### PR TITLE
missed misnamed import in models init

### DIFF
--- a/rgblent_api/models/__init__.py
+++ b/rgblent_api/models/__init__.py
@@ -1,4 +1,4 @@
 from .color import Color
 from .user_color import UserColor
 from .palette import Palette
-from .palette_user import PaletteUser
+from .palette_color import PaletteColor


### PR DESCRIPTION
Silly fix for a mistake I made while preoccupied with fixture generation.
