### PR TITLE
Color Retrieval

### DIFF
--- a/init_database.sh
+++ b/init_database.sh
@@ -2,9 +2,11 @@
 
 API_APP="rgblent_api"
 
+retry_count=$2
 retry_with_migrations() {
+	[ $retry_count -gt 2 ] && exit 1
 	# execute again with "migrations" argument
-	./$0 migrations
+	./$0 migrations $(( ${retry_count:-0} + 1 ))
 	# and exit entirely with return code
 	exit $?
 }
@@ -32,7 +34,7 @@ else
 fi
 
 # if default colors won't load, try rebuilding migrations
-load default_colors ||  retry_with_migrations
+load default_colors || retry_with_migrations
 load users
 load tokens
 load palettes

--- a/rgblent/urls.py
+++ b/rgblent/urls.py
@@ -13,9 +13,16 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.urls import include, path
 from django.contrib import admin
 from django.urls import path
+from rest_framework import routers
+from rgblent_api.views import ColorView
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'colors', ColorView, 'color')
 
 urlpatterns = [
+    path('', include(router.urls)),
     path('admin/', admin.site.urls),
 ]

--- a/rgblent_api/fixtures/default_colors.json
+++ b/rgblent_api/fixtures/default_colors.json
@@ -3,6 +3,7 @@
     "pk": 1,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 255,
       "green": 223,
       "blue": 128,
@@ -13,6 +14,7 @@
     "pk": 2,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 191,
       "green": 255,
       "blue": 128,
@@ -23,6 +25,7 @@
     "pk": 3,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 128,
       "green": 255,
       "blue": 159,
@@ -33,6 +36,7 @@
     "pk": 4,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 128,
       "green": 255,
       "blue": 255,
@@ -43,6 +47,7 @@
     "pk": 5,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 128,
       "green": 159,
       "blue": 255,
@@ -53,6 +58,7 @@
     "pk": 6,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 191,
       "green": 128,
       "blue": 255,
@@ -63,6 +69,7 @@
     "pk": 7,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 255,
       "green": 128,
       "blue": 223,
@@ -73,6 +80,7 @@
     "pk": 8,
     "model": "rgblent_api.Color",
     "fields": {
+      "is_default": true,
       "red": 255,
       "green": 128,
       "blue": 128,

--- a/rgblent_api/fixtures/palettes.json
+++ b/rgblent_api/fixtures/palettes.json
@@ -45,7 +45,7 @@
       "builtin": true,
       "palette": 1,
       "color": 4,
-      "label": "light blue"
+      "label": "cyan"
     }
   },
   {

--- a/rgblent_api/models/color.py
+++ b/rgblent_api/models/color.py
@@ -26,4 +26,4 @@ class Color(models.Model):
     def rgb_hex(self):
         # "02" means:   pad with 2 of "0"
         # "X" means:    print as uppercase hex
-        return "#{:02X}{:02X}{:02X}".format(red, green, blue)
+        return "#{:02X}{:02X}{:02X}".format(self.red, self.green, self.blue)

--- a/rgblent_api/models/color.py
+++ b/rgblent_api/models/color.py
@@ -21,3 +21,9 @@ class Color(models.Model):
     alpha = models.FloatField(default=1.0)
     builtin = models.BooleanField(default=False)
     is_default = models.BooleanField(default=False)
+
+    @property
+    def rgb_hex(self):
+        # "02" means:   pad with 2 of "0"
+        # "X" means:    print as uppercase hex
+        return "#{:02X}{:02X}{:02X}".format(red, green, blue)

--- a/rgblent_api/views/__init__.py
+++ b/rgblent_api/views/__init__.py
@@ -1,0 +1,1 @@
+from .color import ColorView

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -23,7 +23,6 @@ class ColorView(ViewSet):
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):
-        # TODO: search favorites by label
         colors = Color.objects.get(pk=pk)
         serializer = ColorSerializer(
             colors, context={'request': request})

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -11,7 +11,8 @@ class ColorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Color
         # TODO: handle alpha
-        fields = ('id', 'hex', 'red', 'green', 'blue', 'builtin', 'is_default')
+        fields = ('id', 'rgb_hex', 'red', 'green',
+                  'blue', 'builtin', 'is_default')
 
 
 class ColorView(ViewSet):

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -21,3 +21,17 @@ class ColorView(ViewSet):
         serializer = ColorSerializer(
             colors, many=True, context={'request': request})
         return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        # TODO: search favorites by label
+        colors = Color.objects.get(pk=pk)
+        serializer = ColorSerializer(
+            colors, context={'request': request})
+        return Response(serializer.data)
+
+    @action(methods=['get'], detail=False)
+    def defaults(self, request):
+        colors = Color.objects.filter(is_default=True)
+        serializer = ColorSerializer(
+            colors, many=True, context={'request': request})
+        return Response(serializer.data)

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from rest_framework import status
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework.decorators import action
+from rgblent_api.models import Color, UserColor
+
+
+class ColorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Color
+        # TODO: handle alpha
+        fields = ('id', 'hex', 'red', 'green', 'blue', 'builtin', 'is_default')
+
+
+class ColorView(ViewSet):
+    def list(self, request):
+        colors = Color.objects.all()
+        serializer = ColorSerializer(
+            colors, many=True, context={'request': request})
+        return Response(serializer.data)

--- a/rgblent_httparty.rb
+++ b/rgblent_httparty.rb
@@ -10,15 +10,13 @@ class RGBlent
     @options = { headers: { "Authorization": "Token #{token}" } }
   end
 
-  def color(pk: nil)
-    response = self.class.get(
-      "/colors#{pk.class == 1.class ? "/" + pk.to_str : ""}",
-      @options
-    )
+  def color()
+    response = self.class.get("/colors", @options)
+    response.parsed_response
+  end
 
-    for color in response.parsed_response
-      puts color
-    end
+  def get(path)
+    response = self.class.get(path, @options).parsed_response
   end
 end
 

--- a/rgblent_httparty.rb
+++ b/rgblent_httparty.rb
@@ -11,8 +11,15 @@ class RGBlent
   end
 
   def color(pk: nil)
-    self.class.get("/colors#{pk.class == 1.class ? "/" + pk.to_str : ""}", @options)
+    response = self.class.get(
+      "/colors#{pk.class == 1.class ? "/" + pk.to_str : ""}",
+      @options
+    )
+
+    for color in response.parsed_response
+      puts color
+    end
   end
 end
 
-$tokens = { "joe": "9ba45f09651c5b0c404f37a2d2572c026c146694" }
+$joe = RGBlent.new("9ba45f09651c5b0c404f37a2d2572c026c146694")

--- a/rgblent_httparty.rb
+++ b/rgblent_httparty.rb
@@ -1,0 +1,18 @@
+require "httparty"
+require "json"
+require "json"
+
+class RGBlent
+  include HTTParty
+  base_uri "localhost:8000"
+
+  def initialize(token)
+    @options = { headers: { "Authorization": "Token #{token}" } }
+  end
+
+  def color(pk: nil)
+    self.class.get("/colors#{pk.class == 1.class ? "/" + pk.to_str : ""}", @options)
+  end
+end
+
+$tokens = { "joe": "9ba45f09651c5b0c404f37a2d2572c026c146694" }


### PR DESCRIPTION
## FIXES:

- Fixed a possible infinite loop in `init_database.sh` by using a second argument to track retry attempts.
	- This is a bit fragile -- it works because retries always pass an argument enabling a hardcoded check of `$2` for a number of retries. Not a big worry, though, as I have plenty of argument handling code in old scripts (not to mention `getopt`) if I did need to replace the current arrangement.

## CHANGES:

- Added router to `rgblent/urls.py`
	- wires any registered views to the root
- Added ColorView
	- created `rgblent_api/views/colors.py`
	- exported via `.../views/__init__.py`
	- enabled via router
- Created a new `rgb_hex` property on the Color model in `rgblent_api/models/color.py`

## TO TEST:

- Test the ColorView
	- with Ruby and `pry`
		- start the interpreter: `pry -r ./rgblent_httparty.rb`
		- get all colors as user Joe: `$joe.get("/colors")`
		- get default colors as Joe: `$joe.get("/colors/default")`
		- get a single color as Joe: `$joe.get("/colors/5")`
	- you can also manually request as Joe via `curl` or Postman
		- add the header `Authorization: Token 9ba45f09651c5b0c404f37a2d2572c026c146694`
		- GET `/colors`
		- GET `/colors/default`
		- GET `/colors/5`

- Test `rgb_hex`
        - look at one of the retrieved colors
                - each of the color fields is a number from 0-255
                - the `rgb_hex` code should match up to the 2-digit hex representations of each color in the order `red`, `green`, `blue`
        - 

## EXTRAS:

There is a little ruby file that defines an HTTParty class for quick testing in a Ruby interpreter like `pry` or `irb`. It's easier to rapidly switch between test users and reference past results in `pry`, I've found.

### Installing Ruby Tools

- grab `ruby` and `pry` via your preferred package manager (`brew`, `apt`, `pkg` etc.)
- use `gem install` to install `httparty`
