### PR TITLE
Color Info

### DIFF
--- a/colormath.md
+++ b/colormath.md
@@ -1,0 +1,16 @@
+# My Notes on `python-colormath`
+
+## Clamped RGB Values
+
+Some colorspaces (like CIE spaces) are larger than RGB spaces. When converting from CIE to RGB, use `clamped_rgb_{r,g,b}` properties to avoid invalid values.
+
+## Conversion
+
+Some color conversions go through RGB space. By default `colormath` goes through sRGB space when converting and I have no plans to deviate from that yet.
+
+## Color Information Handling
+
+The frontend and backend communicate in RGB-as-a-hex-string in all cases **except:**
+	
+	- `/colors/info` which takes a hex string but returns other colorspace info
+

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rgblent_api.models import Color, UserColor
+from utils.color import color_info
 
 
 class ColorSerializer(serializers.ModelSerializer):
@@ -38,4 +39,4 @@ class ColorView(ViewSet):
     @action(methods=['post'], detail=False)
     def info(self, request):
         rgb_hex = request.data["rgb_hex"]
-        return Response({"rgb_hex": rgb_hex})
+        return Response(color_info(rgb_hex))

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -34,3 +34,8 @@ class ColorView(ViewSet):
         serializer = ColorSerializer(
             colors, many=True, context={'request': request})
         return Response(serializer.data)
+
+    @action(methods=['post'], detail=False)
+    def info(self, request):
+        rgb_hex = request.data["rgb_hex"]
+        return Response({"rgb_hex": rgb_hex})

--- a/rgblent_httparty.rb
+++ b/rgblent_httparty.rb
@@ -18,6 +18,14 @@ class RGBlent
   def get(path)
     response = self.class.get(path, @options).parsed_response
   end
+
+  def get(path)
+    response = self.class.get(path, @options).parsed_response
+  end
+
+  def info(rgb_hex)
+    response = self.class.post("/colors/info", :headers => @options[:headers], :body => { "rgb_hex": rgb_hex }).parsed_response
+  end
 end
 
 $joe = RGBlent.new("9ba45f09651c5b0c404f37a2d2572c026c146694")

--- a/utils/color.py
+++ b/utils/color.py
@@ -1,0 +1,17 @@
+from colormath.color_objects import sRGBColor, HSLColor, HSVColor, LabColor, XYZColor
+from colormath.color_conversions import convert_color
+
+
+def rgb_hex__int_tuple(rgb_hex):
+    return (int(rgb_hex[1:3], 16), int(rgb_hex[3:5], 16), int(rgb_hex[5:7], 16))
+
+
+def color_info(rgb_hex):
+    srgb = sRGBColor(*rgb_hex__int_tuple(rgb_hex))
+    return {
+        "rgb": srgb.__dict__,
+        "hsl": convert_color(srgb, HSLColor).__dict__,
+        "hsv": convert_color(srgb, HSVColor).__dict__,
+        "lab": convert_color(srgb, LabColor).__dict__,
+        "xyz": convert_color(srgb, XYZColor).__dict__
+    }


### PR DESCRIPTION
## CHANGES:

- `rgblent_api/views/color.py`
	- made a quick and surprisingly clean stateless view for color info
- `utils/color.py`
	- created `color_info` function

## UPDATES:

There is now a little document with my notes about `colormath` called `colormath.md`.
