### PR TITLE
Color Info is Public

### DIFF
--- a/rgblent/urls.py
+++ b/rgblent/urls.py
@@ -17,12 +17,13 @@ from django.urls import include, path
 from django.contrib import admin
 from django.urls import path
 from rest_framework import routers
-from rgblent_api.views import ColorView
+from rgblent_api.views import ColorView, colorinfo
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'colors', ColorView, 'color')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('colorinfo', colorinfo),
     path('admin/', admin.site.urls),
 ]

--- a/rgblent_api/views/__init__.py
+++ b/rgblent_api/views/__init__.py
@@ -1,1 +1,1 @@
-from .color import ColorView
+from .color import ColorView, colorinfo

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -3,7 +3,8 @@ from rest_framework import status
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
-from rest_framework.decorators import action
+from rest_framework.decorators import action, permission_classes, api_view
+from rest_framework.permissions import AllowAny
 from rgblent_api.models import Color, UserColor
 from utils.color import color_info
 
@@ -36,7 +37,9 @@ class ColorView(ViewSet):
             colors, many=True, context={'request': request})
         return Response(serializer.data)
 
-    @action(methods=['post'], detail=False)
-    def info(self, request):
-        rgb_hex = request.data["rgb_hex"]
-        return Response(color_info(rgb_hex))
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def colorinfo(request):
+    rgb_hex = request.data["rgb_hex"]
+    return Response(color_info(rgb_hex))

--- a/rgblent_httparty.rb
+++ b/rgblent_httparty.rb
@@ -24,7 +24,7 @@ class RGBlent
   end
 
   def info(rgb_hex)
-    response = self.class.post("/colors/info", :headers => @options[:headers], :body => { "rgb_hex": rgb_hex }).parsed_response
+    response = self.class.post("/colorinfo", :headers => @options[:headers], :body => { "rgb_hex": rgb_hex }).parsed_response
   end
 end
 


### PR DESCRIPTION
## CHANGES:
- `rgblent_api/views/color`
	- moved `info` from the main color ViewSet -- it is now `colorinfo`
	- `colorinfo` is a POST view that is not authentication
- `rgblent/urls.py` and `rgblent_api/views/__init__.py`
	- enabled the `/colorinfo` view with function `colorinfo`

## TO TEST:

- GET color (in the form of a hex string) info
	- POST to `/colorinfo` => `{ "rgb_hex": "#a8dfa3" }`
