### PR TITLE
Public Color Views

### DIFF
--- a/rgblent/settings.py
+++ b/rgblent/settings.py
@@ -54,10 +54,11 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10
 }
 
-CORS_ORIGIN_WHITELIST = (
+CORS_ALLOWED_ORIGINS = (
     'http://localhost:3000',
-    'http://127.0.0.1:3000'
+    'http://127.0.0.1:3000',
 )
+
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/rgblent/urls.py
+++ b/rgblent/urls.py
@@ -17,7 +17,7 @@ from django.urls import include, path
 from django.contrib import admin
 from django.urls import path
 from rest_framework import routers
-from rgblent_api.views import ColorView, colorinfo
+from rgblent_api.views import ColorView, colorinfo, default_colors
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'colors', ColorView, 'color')
@@ -25,5 +25,6 @@ router.register(r'colors', ColorView, 'color')
 urlpatterns = [
     path('', include(router.urls)),
     path('colorinfo', colorinfo),
+    path('default/colors', default_colors),
     path('admin/', admin.site.urls),
 ]

--- a/rgblent/urls.py
+++ b/rgblent/urls.py
@@ -17,7 +17,7 @@ from django.urls import include, path
 from django.contrib import admin
 from django.urls import path
 from rest_framework import routers
-from rgblent_api.views import ColorView, colorinfo, default_colors
+from rgblent_api.views import ColorView, colorinfo, default_colors, default_palette
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'colors', ColorView, 'color')
@@ -26,5 +26,6 @@ urlpatterns = [
     path('', include(router.urls)),
     path('colorinfo', colorinfo),
     path('default/colors', default_colors),
+    path('default/palette', default_palette),
     path('admin/', admin.site.urls),
 ]

--- a/rgblent_api/models/palette_color.py
+++ b/rgblent_api/models/palette_color.py
@@ -12,8 +12,10 @@ class PaletteColor(models.Model):
             color (ForeignKey): the color to associate with the palette
             label (CharField): the label for this color in the context of this palette
         """
-    palette = models.ForeignKey("Palette", on_delete=models.CASCADE)
+    palette = models.ForeignKey(
+        "Palette", related_name="colors", on_delete=models.CASCADE)
     # RESTRICT keeps colors from being deleted if they are referenced somewhere
-    color = models.ForeignKey("Color", on_delete=models.RESTRICT)
+    color = models.ForeignKey(
+        "Color", related_name="palette_color", on_delete=models.RESTRICT)
     label = models.CharField(max_length=PALETTECOLOR_LABEL_MAX_LENGTH)
     builtin = models.BooleanField(default=False)

--- a/rgblent_api/views/__init__.py
+++ b/rgblent_api/views/__init__.py
@@ -1,1 +1,2 @@
 from .color import ColorView, colorinfo, default_colors
+from .palette import default_palette

--- a/rgblent_api/views/__init__.py
+++ b/rgblent_api/views/__init__.py
@@ -1,1 +1,1 @@
-from .color import ColorView, colorinfo
+from .color import ColorView, colorinfo, default_colors

--- a/rgblent_api/views/color.py
+++ b/rgblent_api/views/color.py
@@ -43,3 +43,11 @@ class ColorView(ViewSet):
 def colorinfo(request):
     rgb_hex = request.data["rgb_hex"]
     return Response(color_info(rgb_hex))
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def default_colors(request):
+    colors = Color.objects.filter(isDefault=True)
+    serializer = ColorSerializer(colors, context={'request': request})
+    return Response(serializer.data)

--- a/rgblent_api/views/palette.py
+++ b/rgblent_api/views/palette.py
@@ -1,0 +1,33 @@
+from django.conf import settings
+from rest_framework import status
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework.decorators import action, permission_classes, api_view
+from rest_framework.permissions import AllowAny
+from rgblent_api.models import Palette, PaletteColor
+from .color import ColorSerializer
+
+
+class PaletteColorSerializer(serializers.ModelSerializer):
+    color = ColorSerializer()
+
+    class Meta:
+        model = PaletteColor
+        fields = ('builtin', 'label', 'color')
+
+
+class PaletteSerializer(serializers.ModelSerializer):
+    colors = PaletteColorSerializer(many=True)
+
+    class Meta:
+        model = Palette
+        fields = ('name', 'colors')
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def default_palette(request):
+    palette = Palette.objects.get(builtin=True, name="default")
+    serializer = PaletteSerializer(palette, context={'request': request})
+    return Response(serializer.data)

--- a/utils/color.py
+++ b/utils/color.py
@@ -15,3 +15,11 @@ def color_info(rgb_hex):
         "lab": convert_color(srgb, LabColor).__dict__,
         "xyz": convert_color(srgb, XYZColor).__dict__
     }
+
+
+def make_interpolations(color_obj, steps=64, ColorClass=None):
+    if ColorClass is not None:
+        color_obj = convert_color(color_obj, ColorClass)
+    color_dict = color_obj.__dict__
+    interpolations = {}
+    return interpolations

--- a/utils/color.py
+++ b/utils/color.py
@@ -17,9 +17,3 @@ def color_info(rgb_hex):
     }
 
 
-def make_interpolations(color_obj, steps=64, ColorClass=None):
-    if ColorClass is not None:
-        color_obj = convert_color(color_obj, ColorClass)
-    color_dict = color_obj.__dict__
-    interpolations = {}
-    return interpolations


### PR DESCRIPTION
## CHANGES:
- `rgblent_api/views/color.py`
  - created `default_colors` view with `AllowAny` permission class
- `rgblent_api/views/palettes.py`
  - created `default_palettes` view with `AllowAny` permission class
- `rgblent_api/views/__init__.py` and `rgblent/urls.py`
  - enabled the `default_colors` and `default_palettes` views at `/default/%name` paths

## FIXES:

- `rgblent_api/models/palette_color.py`
  - PaletteColors model was missing it's `related_name` field for it's relationship to Color model